### PR TITLE
fix(core): Fixes PR CI running on draft PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   main:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ (github.event_name != 'pull_request') || (!github.event.pull_request.draft)  }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description
Fixes CI not running when draft PRs are converted to review-ready
- CI is paused if review-ready PR is converted back to draft
- Not 100% sure if this will run on main, please verify my workflow trigger logic


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Evidence / Demo
![image](https://user-images.githubusercontent.com/68502356/194557060-d2d618b9-f72c-4fbe-add5-c22b97ef75da.png)



# How Has This Been Tested?
Tested on the spec-dropdown PR in this sequence
1. Created draft PR #30 
2. Changed if condition of PR
3. Marked PR review-ready
4. Pushed commit
- Main CI runs
5. Marked PR as draft
6. Pushed commit
- Main CI skipped

**Test Configuration**:
* Browser:
* Device: <!-- Computer / Mobile -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged
